### PR TITLE
Support config values on Whatsapp class

### DIFF
--- a/src/Whatsapp.php
+++ b/src/Whatsapp.php
@@ -26,10 +26,10 @@ class Whatsapp
 
     public function __construct(string $whatsappSession = null, HttpClient $httpClient = null, string $apiBaseUri = null, array $configMapMethods = [])
     {
-        $this->whatsappSession = $whatsappSession;
+        $this->whatsappSession = $whatsappSession ?? config('whatsapp-notification-channel.services.whatsapp-bot-api.whatsappSession');
         $this->http = $httpClient ?? new HttpClient();
-        $this->setApiBaseUri($apiBaseUri ?? 'http://localhost:3000');
-        $this->configMethods = $configMapMethods;
+        $this->setApiBaseUri($apiBaseUri ?? config('whatsapp-notification-channel.services.whatsapp-bot-api.base_uri') ?? 'http://localhost:3000');
+        $this->configMethods = $configMapMethods ?: config('whatsapp-notification-channel.services.whatsapp-bot-api.mapMethods') ?: [];
     }
 
     /**
@@ -152,7 +152,7 @@ class Whatsapp
 
         $apiUri = sprintf('%s/%s', $this->apiBaseUri, $endpoint);
         try {
-            $params[config('whatsapp-notification-channel.services.whatsapp-bot-api.whatsappSessionFieldName')] = config('whatsapp-notification-channel.services.whatsapp-bot-api.whatsappSession');
+            $params[config('whatsapp-notification-channel.services.whatsapp-bot-api.whatsappSessionFieldName')] = $this->whatsappSession;
             return $this->httpClient()->post($apiUri, [
                 $multipart ? 'multipart' : 'form_params' => $params,
             ]);


### PR DESCRIPTION
This allows to easily send mensajes without notification channel, example:

```php
$params=['text'=>'string'];
$whatsapp = new \NotificationChannels\Whatsapp\Whatsapp();
$whatsapp->sendMessage(['phone'=>'1111111111']+$params);
$whatsapp->sendMessage(['phone'=>'2222222222']+$params);
```

Also allows setting custom session:
```php
$whatsapp = new \NotificationChannels\Whatsapp\Whatsapp('MyDinamicSession');
```
Because there is a bug that always get back to default session
https://github.com/felipedamacenoteodoro/laravel-whatsapp-notification-channel/blob/f9f8e5f5673b5e169ae578d9e225c2c6287790ba/src/Whatsapp.php#L155