### PR TITLE
Fix exception message

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -24,7 +24,8 @@ class CouldNotSendNotification extends Exception
         $statusCode = $exception->getResponse()->getStatusCode();
 
         $result = json_decode($exception->getResponse()->getBody()->getContents(), false);
-        $description = $result->description ?? 'no description given';
+        $result = $result->exception ?? $result;
+        $description = $result->description ?? $result->message ?? 'no description given';
 
         return new static("Whatsapp api responded with an error `{$statusCode} - {$description}`", 0, $exception);
     }


### PR DESCRIPTION
Fix exception when json has `message`, `exception` propertie,
```json
{
  "statusCode":404,
  "message":"We didn't find a session with name 'default'. Please start it first by using POST /sessions/start request",
  "error":"Not Found"
}
```
```json
{
  ///
  "exception" : {
    "stack":"TypeError: Cannot read properties of unde (truncated...",
    "statusCode":500,
    "message":"Cannot read properties of undefined request",
    "trace":[]
  }
  ///
}
```
