### PR TITLE
Support api key on requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,4 +10,5 @@
 /tests              export-ignore
 /.github            export-ignore
 /.editorconfig      export-ignore
+/CONTRIBUTING.md    export-ignore
 /.php-cs-fixer.dist.php export-ignore

--- a/config/whatsapp-notification-channel/services.php
+++ b/config/whatsapp-notification-channel/services.php
@@ -5,6 +5,7 @@ return [
     'whatsapp-bot-api' => [
         'whatsappSessionFieldName' => env('WHATSAPP_API_SESSION_FIELD_NAME', ''),
         'whatsappSession' => env('WHATSAPP_API_SESSION', ''),
+        'whatsappApiKey' => env('WHATSAPP_API_KEY'),
         'base_uri' => env('WHATSAPP_API_BASE_URL', ''),
         'mapMethods' => [
             'sendMessage' => 'sendText',

--- a/src/Whatsapp.php
+++ b/src/Whatsapp.php
@@ -21,6 +21,8 @@ class Whatsapp
 
     protected $configMethods;
 
+    protected $apiKey;
+
     /** @var string Whatsapp Bot API Base URI */
     protected $apiBaseUri;
 
@@ -30,6 +32,7 @@ class Whatsapp
         $this->http = $httpClient ?? new HttpClient();
         $this->setApiBaseUri($apiBaseUri ?? config('whatsapp-notification-channel.services.whatsapp-bot-api.base_uri') ?? 'http://localhost:3000');
         $this->configMethods = $configMapMethods ?: config('whatsapp-notification-channel.services.whatsapp-bot-api.mapMethods') ?: [];
+        $this->apiKey = config('whatsapp-notification-channel.services.whatsapp-bot-api.whatsappApiKey');
     }
 
     /**
@@ -155,6 +158,7 @@ class Whatsapp
             $params[config('whatsapp-notification-channel.services.whatsapp-bot-api.whatsappSessionFieldName')] = $this->whatsappSession;
             return $this->httpClient()->post($apiUri, [
                 $multipart ? 'multipart' : 'form_params' => $params,
+                'headers' => $this->apiKey ? ['X-Api-Key' => $this->apiKey] : []
             ]);
         } catch (ClientException $exception) {
             throw CouldNotSendNotification::whatsappRespondedWithAnError($exception);


### PR DESCRIPTION
This adds security according to the documentation, without this with ApiKey i get 401 exception
```
Whatsapp api responded with an error `401 - Unauthorized`
```