### PR TITLE
Fix method typo

### DIFF
--- a/src/Whatsapp.php
+++ b/src/Whatsapp.php
@@ -106,9 +106,20 @@ class Whatsapp
      *
      * @throws CouldNotSendNotification
      */
-    public function sendLis(array $params): ?ResponseInterface
+    public function sendList(array $params): ?ResponseInterface
     {
         return $this->sendRequest('sendList', $params);
+    }
+
+    /**
+     * Send a Poll.
+     *
+     * @deprecated Use sendList(array $params): ?ResponseInterface.
+     * @throws CouldNotSendNotification
+     */
+    public function sendLis(array $params): ?ResponseInterface
+    {
+        return $this->sendList($params);
     }
 
     /**


### PR DESCRIPTION
Is `sendLis` a typo of `sendList`?
https://github.com/felipedamacenoteodoro/laravel-whatsapp-notification-channel/blob/accc5aeed25934d4be10379ed4392f617c2d2c0a/src/Whatsapp.php#L109-L112