### PR TITLE
Support other APIs number payload

### DIFF
--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -18,13 +18,15 @@ trait HasSharedLogic
     /**
      * Recipient's Number.
      *
-     * @param int|string $chatId
+     * @param int|string $number
      *
      * @return $this
      */
     public function to($number): self
     {
         $this->payload['number'] = $number;
+        $this->payload['phone'] = $number;
+        $this->payload['chatId'] = $number;
 
         return $this;
     }


### PR DESCRIPTION
in #12 note that different servers handle their own format, could be `phone`, `chatId`
```json
// wppconnect-server POST /api/{session}/send-message
{
  "phone": "11111111111",
  "message": "Hello World",
  "isGroup": false
}
// whatsapp-api POST /api/sendText
{
  "chatId": "11111111111",
  "text": "Hello World",
  "session": "default"
}
```
But for files need a better refactor for other servers support