### PR TITLE
Support other APIs message payload

### DIFF
--- a/src/WhatsappChannel.php
+++ b/src/WhatsappChannel.php
@@ -78,7 +78,7 @@ class WhatsappChannel
                     $messages = $this->chunk($message->getPayloadValue('text'), $message->chunkSize);
 
                     $payloads = collect($messages)->filter()->map(function ($text) use ($params) {
-                        return array_merge($params, ['text' => $text]);
+                        return array_merge($params, ['text' => $text, 'message' => $text]);
                     });
 
                     if ($replyMarkup) {

--- a/src/WhatsappMessage.php
+++ b/src/WhatsappMessage.php
@@ -20,6 +20,7 @@ class WhatsappMessage implements JsonSerializable
     {
         $this->content($content);
         $this->payload['parse_mode'] = 'Markdown';
+        $this->payload['isGroup'] = false;
     }
 
     public static function create(string $content = ''): self
@@ -35,6 +36,7 @@ class WhatsappMessage implements JsonSerializable
     public function content(string $content, int $limit = null): self
     {
         $this->payload['text'] = $content;
+        $this->payload['message'] = $content;
 
         if ($limit) {
             $this->chunkSize = $limit;


### PR DESCRIPTION
in https://github.com/felipedamacenoteodoro/laravel-whatsapp-notification-channel/issues/12 note that different servers handle their own format, could be `text`, `message`

```json
// wppconnect-server POST /api/{session}/send-message
{
  "phone": "11111111111",
  "message": "Hello World",
  "isGroup": false
}
// whatsapp-api POST api/sendText
{
  "chatId": "11111111111",
  "text": "Hello World",
  "session": "default"
}
```
But for files need a better refactor for other servers support