### PR TITLE
Use json instead of form_params

### DIFF
--- a/src/Whatsapp.php
+++ b/src/Whatsapp.php
@@ -154,7 +154,7 @@ class Whatsapp
         try {
             $params[config('whatsapp-notification-channel.services.whatsapp-bot-api.whatsappSessionFieldName')] = $this->whatsappSession;
             return $this->httpClient()->post($apiUri, [
-                $multipart ? 'multipart' : 'form_params' => $params,
+                $multipart ? 'multipart' : 'json' => $params,
             ]);
         } catch (ClientException $exception) {
             throw CouldNotSendNotification::whatsappRespondedWithAnError($exception);


### PR DESCRIPTION
@felipedamacenoteodoro Is there a reason to use `form_params`?
With `form_params` content-type is `application/x-www-form-urlencoded`
But documentation says that must be `application/json`

With `application/x-www-form-urlencoded`
This
```json
{
  "chatId": "1111111111",
  "file": {
    "mimetype": "image/jpeg",
    "filename": "filename.jpeg",
    "data": "BASE64_DATA"
  },
  "caption": "test 1",
  "text": "test 2",
  "session": "default"
}
```
Becomes 
```
chatId: 1111111111
file[mimetype]: image/jpeg
file[filename]: filename.jpeg
file[data]: BASE64_DATA
caption: test 1
text: test 2
session: default
```
And it breaks functionality on apis
https://wppconnect.io/swagger/wppconnect-server/#tag/Send-Message/operation/SendImage
https://waha.devlike.pro/swagger/#/chatting/ChattingController_sendImage
https://docs.guzzlephp.org/en/stable/request-options.html#json