### PR TITLE
Support file sending on other APIs

### DIFF
--- a/src/WhatsappFile.php
+++ b/src/WhatsappFile.php
@@ -45,7 +45,7 @@ class WhatsappFile implements JsonSerializable
      *
      * Generic method to attach files of any type based on API.
      *
-     * @param resource|StreamInterface|string $file
+     * @param resource|StreamInterface|string|array $file
      *
      * @return $this
      */
@@ -55,6 +55,12 @@ class WhatsappFile implements JsonSerializable
 
         if (null !== $filename) {
             $this->payload['fileName'] = $filename;
+        }
+        
+        if (is_array($file) {
+            $this->payload = array_merge($this->payload, $file);
+
+            return $this;
         }
 
         if (is_string($file) && !$this->isReadableFile($file)) {
@@ -160,7 +166,7 @@ class WhatsappFile implements JsonSerializable
      */
     public function hasFile(): bool
     {
-        return isset($this->payload['file']);
+        return is_array($this->payload['file'] ?? null) && is_resource($this->payload['file']['contents'] ?? null);
     }
 
     /**


### PR DESCRIPTION
Closes #12
This allows us to do
```php
public function toWhatsapp($notifiable)
{
    return WhatsappFile::create()
            ->to($notifiable->whatsapp_number) // Optional
            ->content('Caption') // Optional Caption
            ->file([
                "file"=> [
                  "mimetype"=> "image/jpeg",
                  "filename"=> "filename.jpeg",
                  "data"=> "BASE64_DATA",
                ]
            ], 'image');
}
```
```php
public function toWhatsapp($notifiable)
{
    return WhatsappFile::create()
            ->to($notifiable->whatsapp_number) // Optional
            ->content('Caption') // Optional Caption
            ->file([
                "base64"=> "BASE64_DATA",
                "filename"=> "filename.jpeg",
                "isGroup"=> false,
            ], 'image');
}
```
https://wppconnect.io/swagger/wppconnect-server/#tag/Send-Message/operation/SendImage
https://waha.devlike.pro/swagger/#/chatting/ChattingController_sendImage